### PR TITLE
Feature/keyword recommend

### DIFF
--- a/src/main/java/com/estsoft/astronautbe/controller/keyword/KeywordController.java
+++ b/src/main/java/com/estsoft/astronautbe/controller/keyword/KeywordController.java
@@ -17,7 +17,6 @@ import com.estsoft.astronautbe.repository.RecommendKeywordStockRepository;
 import com.estsoft.astronautbe.service.KeywordService;
 
 @RestController
-@CrossOrigin(origins = {"http://localhost:3000", "http://127.0.0.1:3000"})
 public class KeywordController {
 
 	private final KeywordService keywordService;

--- a/src/main/java/com/estsoft/astronautbe/controller/keyword/KeywordController.java
+++ b/src/main/java/com/estsoft/astronautbe/controller/keyword/KeywordController.java
@@ -1,47 +1,62 @@
 package com.estsoft.astronautbe.controller.keyword;
 
-import java.util.Arrays;
 import java.util.List;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.estsoft.astronautbe.domain.dto.RecommendKeywordStockRequestDTO;
-import com.estsoft.astronautbe.domain.dto.RecommendKeywordStockResponseDTO;
-import com.estsoft.astronautbe.domain.dto.SearchVolumeRequestDTO;
-import com.estsoft.astronautbe.domain.dto.SearchVolumeResponseDTO;
+import com.estsoft.astronautbe.domain.RecommendKeywordStock;
+import com.estsoft.astronautbe.domain.SearchVolume;
+import com.estsoft.astronautbe.repository.RecommendKeywordStockRepository;
 import com.estsoft.astronautbe.service.KeywordService;
 
 @RestController
 public class KeywordController {
 
-	private final KeywordService service;
+	private final KeywordService keywordService;
+	private final RecommendKeywordStockRepository recommendKeywordStockRepository;
 
-	public KeywordController(KeywordService service) {
-		this.service = service;
-
+	public KeywordController(KeywordService keywordService,
+			RecommendKeywordStockRepository recommendKeywordStockRepository) {
+		this.keywordService = keywordService;
+		this.recommendKeywordStockRepository = recommendKeywordStockRepository;
 	}
 
 	// GET -  키워드를 받아 Alan으로 추천 종목 5개 추출 API
-	@GetMapping("/api/keywords/recommend")
-	public ResponseEntity<List<RecommendKeywordStockResponseDTO>> getRecommendKeywordStock(@RequestParam(name = "content") String keyword){
-		RecommendKeywordStockRequestDTO request = new RecommendKeywordStockRequestDTO(keyword);
-		List<RecommendKeywordStockResponseDTO> responseList = service.getRecommendKeywordStock(request);
-		return ResponseEntity.ok(responseList);
+	@GetMapping("/api/keywords/{keyword_id}/recommend")
+	public ResponseEntity<List<RecommendKeywordStock>> getRecommendKeywordStock(
+			@PathVariable("keyword_id") Long keywordId) {
+
+		String keyword = keywordService.getKeywordNameById(keywordId);
+
+		List<RecommendKeywordStock> recommendKeywordStocks = keywordService.getRecommendKeywordStock(keyword, keywordId);
+
+		return ResponseEntity.ok(recommendKeywordStocks);
 	}
 
 	// POST - 종목 리스트를 받아 네이버 검색량 조회 API
-	@PostMapping("/api/keywords")
-	public ResponseEntity<List<SearchVolumeResponseDTO>> getTrends(@RequestBody List<String> keywords) {
-		SearchVolumeRequestDTO request = new SearchVolumeRequestDTO(keywords);
-		List<SearchVolumeResponseDTO> responseList = service.getSearchAmount(request);
+	@PostMapping("/api/keywords/{keyword_id}")
+	public ResponseEntity<List<SearchVolume>> getTrends(@PathVariable("keyword_id") Long keywordId,
+			@RequestBody List<String> stockNames) {
 
-		return ResponseEntity.ok(responseList);
+		// 추천 종목 정보
+		List<RecommendKeywordStock> recommendKeywordStocks = recommendKeywordStockRepository.findByKeyword_KeywordId(
+				keywordId);
+
+		List<SearchVolume> searchVolumes = keywordService.getSearchAmount(stockNames, keywordId, recommendKeywordStocks);
+
+		return ResponseEntity.ok(searchVolumes);
+	}
+
+	// 전체 프로세스 실행
+	@PostMapping("/api/keywords/allProcess")
+	public ResponseEntity<String> processRecommendStockAndSearch() {
+		keywordService.processKeywordRecommendation();
+		return ResponseEntity.ok("전체 프로세스 실행 완료");
 	}
 
 }

--- a/src/main/java/com/estsoft/astronautbe/controller/keyword/KeywordController.java
+++ b/src/main/java/com/estsoft/astronautbe/controller/keyword/KeywordController.java
@@ -1,20 +1,23 @@
 package com.estsoft.astronautbe.controller.keyword;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.estsoft.astronautbe.domain.RecommendKeywordStock;
-import com.estsoft.astronautbe.domain.SearchVolume;
+
+import com.estsoft.astronautbe.domain.dto.RecommendKeywordStockDTO;
+import com.estsoft.astronautbe.domain.dto.SearchVolumeWithStockDTO;
 import com.estsoft.astronautbe.repository.RecommendKeywordStockRepository;
 import com.estsoft.astronautbe.service.KeywordService;
 
 @RestController
+@CrossOrigin(origins = {"http://localhost:3000", "http://127.0.0.1:3000"})
 public class KeywordController {
 
 	private final KeywordService keywordService;
@@ -26,37 +29,33 @@ public class KeywordController {
 		this.recommendKeywordStockRepository = recommendKeywordStockRepository;
 	}
 
-	// GET -  키워드를 받아 Alan으로 추천 종목 5개 추출 API
+	// GET -  키워드를 받아 DB의 추천 종목 5개 추출 API
 	@GetMapping("/api/keywords/{keyword_id}/recommend")
-	public ResponseEntity<List<RecommendKeywordStock>> getRecommendKeywordStock(
+	public List<RecommendKeywordStockDTO> getRecommendKeywordStock(
 			@PathVariable("keyword_id") Long keywordId) {
-
-		String keyword = keywordService.getKeywordNameById(keywordId);
-
-		List<RecommendKeywordStock> recommendKeywordStocks = keywordService.getRecommendKeywordStock(keyword, keywordId);
-
-		return ResponseEntity.ok(recommendKeywordStocks);
+		return keywordService.getRecommendStocks(keywordId);
 	}
 
-	// POST - 종목 리스트를 받아 네이버 검색량 조회 API
-	@PostMapping("/api/keywords/{keyword_id}")
-	public ResponseEntity<List<SearchVolume>> getTrends(@PathVariable("keyword_id") Long keywordId,
-			@RequestBody List<String> stockNames) {
+	// POST - 종목 리스트를 받아 DB에 저장한 네이버 검색량 조회 API
+	@GetMapping("/api/keywords/{keyword_id}")
+	public List<SearchVolumeWithStockDTO> getTrends(@PathVariable("keyword_id") Long keywordId) {
 
-		// 추천 종목 정보
-		List<RecommendKeywordStock> recommendKeywordStocks = recommendKeywordStockRepository.findByKeyword_KeywordId(
-				keywordId);
-
-		List<SearchVolume> searchVolumes = keywordService.getSearchAmount(stockNames, keywordId, recommendKeywordStocks);
-
-		return ResponseEntity.ok(searchVolumes);
+		return keywordService.getRecommendStockWithSearchVolumes(keywordId);
 	}
 
-	// 전체 프로세스 실행
+	// 전체 프로세스 실행 (1일 1회 사용하도록 스케줄러로 설정 필요)
 	@PostMapping("/api/keywords/allProcess")
 	public ResponseEntity<String> processRecommendStockAndSearch() {
 		keywordService.processKeywordRecommendation();
 		return ResponseEntity.ok("전체 프로세스 실행 완료");
+	}
+
+	// 오늘의 키워드 ID 반환(리액트 연결용)
+	@GetMapping("/api/keywords/today")
+	public ResponseEntity<List<Long>> getTodayKeywordsIds() {
+		LocalDateTime today = LocalDateTime.now();
+		List<Long> todayKeywordIds = keywordService.getTodayKeywordIds(today);
+		return ResponseEntity.ok(todayKeywordIds);
 	}
 
 }

--- a/src/main/java/com/estsoft/astronautbe/domain/Keyword.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/Keyword.java
@@ -53,10 +53,5 @@ public class Keyword {
 
 	@Column(name = "ranking", columnDefinition = "INT", nullable = false)
 	private int ranking;
-
-
-	@OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<RecommendKeywordStock> recommendKeywordStocks = new ArrayList<>();
-
-
+	
 }

--- a/src/main/java/com/estsoft/astronautbe/domain/Keyword.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/Keyword.java
@@ -1,16 +1,20 @@
 package com.estsoft.astronautbe.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -49,5 +53,10 @@ public class Keyword {
 
 	@Column(name = "ranking", columnDefinition = "INT", nullable = false)
 	private int ranking;
+
+
+	@OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<RecommendKeywordStock> recommendKeywordStocks = new ArrayList<>();
+
 
 }

--- a/src/main/java/com/estsoft/astronautbe/domain/RecommendKeywordStock.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/RecommendKeywordStock.java
@@ -3,9 +3,11 @@ package com.estsoft.astronautbe.domain;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,6 +26,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "recommend_keyword_stock")
+@EntityListeners(AuditingEntityListener.class)
 public class RecommendKeywordStock {
 
 	@Id
@@ -62,5 +65,12 @@ public class RecommendKeywordStock {
 
 	public String getStockCode() {
 		return this.stock != null ? this.stock.getStockCode() : null;
+	}
+
+	public RecommendKeywordStock(Long recommendStockId, Keyword keyword, Stock stock, String reason) {
+		this.recommendStockId = recommendStockId;
+		this.keyword = keyword;
+		this.stock = stock;
+		this.reason = reason;
 	}
 }

--- a/src/main/java/com/estsoft/astronautbe/domain/RecommendKeywordStock.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/RecommendKeywordStock.java
@@ -6,9 +6,12 @@ import org.springframework.data.annotation.CreatedDate;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,11 +31,13 @@ public class RecommendKeywordStock {
 	@Column(name = "recommend_stock_id", columnDefinition = "BIGINT", nullable = false)
 	private Long recommendStockId;
 
-	@Column(name = "keyword_id", columnDefinition = "BIGINT", nullable = false)
-	private Long keywordId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "keyword_id", referencedColumnName = "keyword_id", nullable = false)
+	private Keyword keyword;
 
-	@Column(name = "stock_code", columnDefinition = "VARCHAR(255)", nullable = false)
-	private String stockCode;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "stock_code", referencedColumnName = "stock_code", nullable = false)
+	private Stock stock;
 
 	@Column(name = "reason", columnDefinition = "TEXT", nullable = false)
 	private String reason;
@@ -41,4 +46,21 @@ public class RecommendKeywordStock {
 	@Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
+	public void setKeywordId(Long keywordId) {
+		this.keyword = new Keyword();
+		this.keyword.setKeywordId(keywordId);
+	}
+
+	public Long getKeywordId() {
+		return this.keyword != null ? this.keyword.getKeywordId() : null;
+	}
+
+	public void setStockCode(String stockCode) {
+		this.stock = new Stock();
+		this.stock.setStockCode(stockCode);
+	}
+
+	public String getStockCode() {
+		return this.stock != null ? this.stock.getStockCode() : null;
+	}
 }

--- a/src/main/java/com/estsoft/astronautbe/domain/SearchVolume.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/SearchVolume.java
@@ -4,13 +4,15 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,11 +32,13 @@ public class SearchVolume {
 	@Column(name = "search_id", columnDefinition = "BIGINT", nullable = false)
 	private Long searchId;
 
-	@Column(name = "recommend_stock_id", columnDefinition = "BIGINT", nullable = false)
-	private Long recommendStockId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "recommend_stock_id", referencedColumnName = "recommend_stock_id", nullable = false)
+	private RecommendKeywordStock recommendKeywordStock;
 
-	@Column(name = "keyword_id", columnDefinition = "BIGINT", nullable = false)
-	private Long keywordId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "keyword_id", referencedColumnName = "keyword_id", nullable = false)
+	private Keyword keyword;
 
 	@Column(name = "search_volume", columnDefinition = "DOUBLE", nullable = false)
 	private Double searchVolume;
@@ -47,5 +51,22 @@ public class SearchVolume {
 	@Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
+	public void setKeywordId(Long keywordId) {
+		this.keyword = new Keyword();
+		this.keyword.setKeywordId(keywordId);
+	}
+
+	public Long getKeywordId() {
+		return this.keyword != null ? this.keyword.getKeywordId() : null;
+	}
+
+	public void setRecommendStockId(Long recommendStockId) {
+		this.recommendKeywordStock = new RecommendKeywordStock();
+		this.recommendKeywordStock.setRecommendStockId(recommendStockId);
+	}
+
+	public Long getRecommendStockId() {
+		return this.recommendKeywordStock != null ? this.recommendKeywordStock.getRecommendStockId() : null;
+	}
 
 }

--- a/src/main/java/com/estsoft/astronautbe/domain/Stock.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/Stock.java
@@ -15,10 +15,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "stock")
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/estsoft/astronautbe/domain/dto/RecommendKeywordStockDTO.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/dto/RecommendKeywordStockDTO.java
@@ -1,0 +1,16 @@
+package com.estsoft.astronautbe.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class RecommendKeywordStockDTO {
+	private Long recommendStockId;
+	private String stockName;
+	private String reason;
+	private String stockPrice;
+
+}

--- a/src/main/java/com/estsoft/astronautbe/domain/dto/SearchVolumeWithStockDTO.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/dto/SearchVolumeWithStockDTO.java
@@ -1,0 +1,19 @@
+package com.estsoft.astronautbe.domain.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SearchVolumeWithStockDTO {
+	private String keywordName;
+	private String stockName;
+	private String stockCode;
+	private LocalDate
+			searchDate;
+	private Double searchVolume;
+
+
+}

--- a/src/main/java/com/estsoft/astronautbe/domain/dto/SearchVolumeWithStockDTO.java
+++ b/src/main/java/com/estsoft/astronautbe/domain/dto/SearchVolumeWithStockDTO.java
@@ -11,8 +11,7 @@ public class SearchVolumeWithStockDTO {
 	private String keywordName;
 	private String stockName;
 	private String stockCode;
-	private LocalDate
-			searchDate;
+	private LocalDate searchDate;
 	private Double searchVolume;
 
 

--- a/src/main/java/com/estsoft/astronautbe/repository/KeywordRepository.java
+++ b/src/main/java/com/estsoft/astronautbe/repository/KeywordRepository.java
@@ -15,6 +15,7 @@ import com.estsoft.astronautbe.domain.Keyword;
 public interface KeywordRepository extends JpaRepository<Keyword,Long> {
 	Optional<Keyword> findByKeywordName(String keywordName);
 
-	@Query("SELECT k FROM Keyword k WHERE DATE(k.createdAt) = :today ")
-	List<Keyword> findByCreatedAtToday(@Param("today") LocalDateTime createdAt);
+	@Query("SELECT k FROM Keyword k WHERE k.createdAt BETWEEN :startOfDay AND :endOfDay")
+	List<Keyword> findByCreatedAtToday(@Param("startOfDay") LocalDateTime startOfDay,
+			@Param("endOfDay") LocalDateTime endOfDay);
 }

--- a/src/main/java/com/estsoft/astronautbe/repository/RecommendKeywordStockRepository.java
+++ b/src/main/java/com/estsoft/astronautbe/repository/RecommendKeywordStockRepository.java
@@ -1,12 +1,14 @@
 package com.estsoft.astronautbe.repository;
 
-import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.estsoft.astronautbe.domain.RecommendKeywordStock;
 
-public interface RecommendKeywordStockRepository extends JpaRepository<RecommendKeywordStock,Long> {
+public interface RecommendKeywordStockRepository extends JpaRepository<RecommendKeywordStock, Long> {
 	RecommendKeywordStock findByRecommendStockId(Long recommendStockId);
-	Optional<RecommendKeywordStock> findByKeywordId(Long keywordId);
+
+	List<RecommendKeywordStock> findByKeyword_KeywordId(Long keywordId);
+
 }

--- a/src/main/java/com/estsoft/astronautbe/repository/SearchVolumeRepository.java
+++ b/src/main/java/com/estsoft/astronautbe/repository/SearchVolumeRepository.java
@@ -1,9 +1,28 @@
 package com.estsoft.astronautbe.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.estsoft.astronautbe.domain.SearchVolume;
 
 public interface SearchVolumeRepository extends JpaRepository<SearchVolume,Long> {
 
+	List<SearchVolume> findByKeyword_KeywordId(Long keywordId);
+
+	@Query(value = "SELECT k.keyword_name, rks.stock_code, sv.search_date, sv.search_volume " +
+			"FROM search_volume sv " +
+			"LEFT JOIN recommend_keyword_stock rks ON sv.recommend_keyword_stock_id = rks.recommend_stock_id " +
+			"LEFT JOIN keyword k ON rks.keyword_id = k.keyword_id " +
+			"WHERE k.keyword_id = :keywordId " +
+			"AND sv.search_date BETWEEN :startDate AND :endDate", nativeQuery = true)
+	List<Object[]> findSearchVolumesWithStockCodeNative(
+			@Param("keywordId") Long keywordId,
+			@Param("startDate") LocalDateTime startDate,
+			@Param("endDate") LocalDateTime endDate);
+
+	List<SearchVolume> findByKeyword_KeywordIdAndRecommendKeywordStock_RecommendStockId(Long keywordId, Long recommendStockId);
 }

--- a/src/main/java/com/estsoft/astronautbe/repository/StockRepository.java
+++ b/src/main/java/com/estsoft/astronautbe/repository/StockRepository.java
@@ -12,5 +12,4 @@ public interface StockRepository extends JpaRepository<Stock, String> {
 
 	List<Stock> findByStockCode(String stockCode);
 
-	Optional<Stock> findStockNameByStockCode(String stockCode);
 }

--- a/src/main/java/com/estsoft/astronautbe/repository/StockRepository.java
+++ b/src/main/java/com/estsoft/astronautbe/repository/StockRepository.java
@@ -1,6 +1,7 @@
 package com.estsoft.astronautbe.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface StockRepository extends JpaRepository<Stock, String> {
 	List<Stock> findStockByStockNameContaining(String query);
 
 	List<Stock> findByStockCode(String stockCode);
+
+	Optional<Stock> findStockNameByStockCode(String stockCode);
 }

--- a/src/main/java/com/estsoft/astronautbe/service/KeywordService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/KeywordService.java
@@ -12,19 +12,17 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
 import org.springframework.http.MediaType;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.estsoft.astronautbe.config.ApiConstants;
-import com.estsoft.astronautbe.domain.dto.RecommendKeywordStockRequestDTO;
-import com.estsoft.astronautbe.domain.dto.RecommendKeywordStockResponseDTO;
 import com.estsoft.astronautbe.domain.dto.RecommendStockAnswer;
 import com.estsoft.astronautbe.domain.dto.SearchVolumeRequestDTO;
 import com.estsoft.astronautbe.domain.dto.SearchVolumeResponseDTO;
@@ -40,7 +38,6 @@ public class KeywordService {
 	private final SearchVolumeRepository searchVolumeRepository;
 	private final RecommendKeywordStockRepository recommendKeywordStockRepository;
 	private final StockRepository stockRepository;
-	private final ClientHttpRequestFactorySettings clientHttpRequestFactorySettings;
 
 	@Value("${naver.client.id}")
 	private String naverClientId;
@@ -65,15 +62,29 @@ public class KeywordService {
 		this.objectMapper = objectMapper;
 		objectMapper.registerModule(new JavaTimeModule());
 		this.stockRepository = stockRepository;
-		this.clientHttpRequestFactorySettings = clientHttpRequestFactorySettings;
+	}
+
+	// 오늘 날짜의 키워드 ID 조회
+	public List<Long> getTodayKeywordIds(LocalDateTime dateTime) {
+		LocalDateTime startOfDay = LocalDateTime.now().toLocalDate().atStartOfDay();
+		LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
+		List<Keyword> keywords = keywordRepository.findByCreatedAtToday(startOfDay, endOfDay);
+		return keywords.stream().map(Keyword::getKeywordId).collect(Collectors.toList());
+	}
+
+	// 추천 키워드 ID로 추천 키워드 이름 반환
+	public String getKeywordNameById(Long keywordId) {
+		Optional<Keyword> keyword = keywordRepository.findById(keywordId);
+		return keyword.map(Keyword::getKeywordName)
+				.orElseThrow(() -> new IllegalArgumentException("키워드 ID가 없습니다. : " + keywordId));
 	}
 
 	// alan api로 추천 종목 뽑아오기
-	public List<RecommendKeywordStockResponseDTO> getRecommendKeywordStock(RecommendKeywordStockRequestDTO request) {
+	public List<RecommendKeywordStock> getRecommendKeywordStock(String keyword, Long keywordId) {
 		try {
 			String url = ApiConstants.ALLEN_API_URL;
 
-			String prompt = request.getContent() + " 키워드에 관련된 국내 주식 추천 종목을 5개 알려줘. " +
+			String prompt = keyword + " 키워드에 관련된 국내 주식 추천 종목을 5개 알려줘. " +
 					"종목 코드, 추천 사유, 답변 생성 시간을 내가 제시하는 json 형태에 넣어줘. " +
 					"답변은 순수한 json 형태로만 보내줘. 다음은 내가 제시하는 형식이야.\n" +
 					"{" +
@@ -98,12 +109,7 @@ public class KeywordService {
 					.bodyToMono(String.class)
 					.block();
 
-			parseRecommendKeywordStock(stringResponse);
-
-			RecommendKeywordStockResponseDTO responseDTO = objectMapper.readValue(stringResponse,
-					RecommendKeywordStockResponseDTO.class);
-
-			return List.of(responseDTO);
+			return parseRecommendKeywordStock(stringResponse, keywordId);
 
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -112,7 +118,8 @@ public class KeywordService {
 	}
 
 	// 응답 가공
-	private List<RecommendKeywordStock> parseRecommendKeywordStock(String stringResponse) throws Exception {
+	private List<RecommendKeywordStock> parseRecommendKeywordStock(String stringResponse, Long keywordId) throws
+			Exception {
 		stringResponse = stringResponse.replace("\\n", "");
 
 		// json으로 파싱
@@ -125,10 +132,10 @@ public class KeywordService {
 				.map(recommendStockData -> {
 					RecommendKeywordStock stock = new RecommendKeywordStock();
 					// 임시 키워드 아이디
-					stock.setKeywordId(1L);
+					stock.setKeywordId(keywordId);
 					stock.setStockCode(recommendStockData.getStockCode());
 					stock.setReason(recommendStockData.getReason());
-					stock.setCreatedAt(recommendStockData.getCreatedAt());
+					stock.setCreatedAt(LocalDateTime.now());
 					return stock;
 				})
 				.collect(Collectors.toList());
@@ -138,10 +145,33 @@ public class KeywordService {
 		return stocks;
 	}
 
+	// 추천 종목 리스트(이름X) 받아 종목 이름 리스트 반환
+	public List<String> getStockNamesByRecommendKeywordStocks(List<RecommendKeywordStock> recommendKeywordStocks) {
+		try {
+			List<String> stockNames = new ArrayList<>();
+			for (RecommendKeywordStock myRecommendStock : recommendKeywordStocks) {
+				List<Stock> stocks = stockRepository.findByStockCode(myRecommendStock.getStockCode());
+				if (!stocks.isEmpty()) {
+					stockNames.add(stocks.get(0).getStockName());
+				}
+			}
+			return stockNames;
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new RuntimeException("주식 정보가 존재하지 않습니다.");
+		}
+	}
 
 	// 단어 리스트로 검색량 조회
-	public List<SearchVolumeResponseDTO> getSearchAmount(SearchVolumeRequestDTO request) {
+	public List<SearchVolume> getSearchAmount(List<String> stockNames, Long keywordId,
+			List<RecommendKeywordStock> recommendKeywordStocks) {
+		if (stockNames == null || stockNames.isEmpty()) {
+			System.out.println("주식 이름 리스트가 비어 있습니다.");
+		}
+
 		String url = ApiConstants.NAVER_TREND_API_URL;
+
+		SearchVolumeRequestDTO request = new SearchVolumeRequestDTO(stockNames);
 
 		SearchVolumeResponseDTO response = webClient.post()
 				.uri(url)
@@ -153,33 +183,58 @@ public class KeywordService {
 				.bodyToMono(SearchVolumeResponseDTO.class)
 				.block();
 
-		List<SearchVolume> searchVolumes = convertToSearchVolumes(response, request);
+		List<SearchVolume> searchVolumes = convertToSearchVolumes(response, request, keywordId, recommendKeywordStocks);
 		searchVolumeRepository.saveAll(searchVolumes);
 
-		return List.of(response);
+		return searchVolumes;
 	}
 
+	// 답변 가공
 	private List<SearchVolume> convertToSearchVolumes(SearchVolumeResponseDTO apiResponse,
-			SearchVolumeRequestDTO request) {
+			SearchVolumeRequestDTO request, Long keywordId, List<RecommendKeywordStock> recommendKeywordStocks) {
 		List<SearchVolume> searchVolumes = new ArrayList<>();
 
-		//title->추천종목에서 찾아서 id로 recommend_stock_id .. 키워드도 동일
-		RecommendKeywordStock recommendKeywordStock = recommendKeywordStockRepository.findByRecommendStockId(1L);
+		for (SearchVolumeResponseDTO.ResultItem resultItem : apiResponse.getResults()) {
+			RecommendKeywordStock matchingStock = recommendKeywordStocks.stream()
+					.filter(stock -> {
+						List<Stock> stocks = stockRepository.findByStockCode(stock.getStockCode());
+						return !stocks.isEmpty() && stocks.get(0).getStockName().equals(resultItem.getTitle());
+					})
+					.findFirst()
+					.orElseThrow(() -> new RuntimeException(("해당하는 주식이 존재하지 않습니다.")));
 
-		for (SearchVolumeResponseDTO.ResultItem result : apiResponse.getResults()) {
 			SearchVolume volume = new SearchVolume();
-			// 임시 아이디
-			volume.setKeywordId(1L);
-			//임시 추천종목 아이디
-			volume.setRecommendStockId(1L);
-			volume.setSearchVolume(Double.parseDouble(result.getData().get(0).getRatio()));
-			volume.setSearchDate( LocalDateTime.parse( result.getData().get(0).getPeriod() + "T00:00:00",
-					DateTimeFormatter.ISO_LOCAL_DATE_TIME ) );
+			volume.setKeywordId(keywordId);
+			volume.setRecommendStockId(matchingStock.getRecommendStockId());
+			volume.setSearchVolume(Double.parseDouble(resultItem.getData().get(0).getRatio()));
+			volume.setSearchDate(
+					LocalDateTime.parse(resultItem.getData().get(0).getPeriod() + "T00:00:00",
+							DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
 			volume.setCreatedAt(LocalDateTime.now());
-
 			searchVolumes.add(volume);
 		}
 
 		return searchVolumes;
+	}
+
+	// 전체 프로세스 실행 메서드
+
+	public void processKeywordRecommendation() {
+
+		// 오늘의 키워드+ID 조회
+		LocalDateTime today = LocalDateTime.now();
+		List<Long> todayKeywordIds = getTodayKeywordIds(today);
+
+		// 각 키워드에 대해 반복
+		for (Long keywordId : todayKeywordIds) {
+			// 키워드 이름 조회
+			String keywordName = getKeywordNameById(keywordId);
+			// 추천 키워드에 관련된 종목 조회
+			List<RecommendKeywordStock> recommendKeywordStocks = getRecommendKeywordStock(keywordName, keywordId);
+			// 키워드 추천 종목 이름 조회
+			List<String> recommendStockNames = getStockNamesByRecommendKeywordStocks(recommendKeywordStocks);
+			// 키워드 추천 종목 검색량 조회
+			List<SearchVolume> searchVolumes = getSearchAmount(recommendStockNames, keywordId, recommendKeywordStocks);
+		}
 	}
 }

--- a/src/main/java/com/estsoft/astronautbe/service/KeywordService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/KeywordService.java
@@ -135,11 +135,9 @@ public class KeywordService {
 		List<RecommendKeywordStock> stocks = answer.getData().stream()
 				.map(recommendStockData -> {
 					RecommendKeywordStock stock = new RecommendKeywordStock();
-					// 임시 키워드 아이디
 					stock.setKeywordId(keywordId);
 					stock.setStockCode(recommendStockData.getStockCode());
 					stock.setReason(recommendStockData.getReason());
-					// stock.setCreatedAt(LocalDateTime.now());
 					return stock;
 				})
 				.collect(Collectors.toList());


### PR DESCRIPTION
## #️⃣연관된 이슈
#25 

## 📝작업 내용

프론트엔드에서 필요한 형식으로 키워드 관련 추천 종목 및 추천 종목의 검색량 파트의 전체 흐름 및 service/controller 수정하였습니다.

- 컨트롤러단
전반적인 api를 리액트에서 필요로 하는 형식으로 반환하도록 변경하였습니다.
실행 속도와 API 연결 횟수 절약을 위하여 processRecommendStockAndSearch()에서 하루 1회 실행하여 DB에 저장하게 한 후, DB에서 내용을 가져올 수 있도록 변경하였습니다. (현재 아직 스케줄러 설정X)

- 서비스단
전반적인 흐름을 조정하였습니다.
추후 스케줄러 설정이 필요합니다. processRecommendStockAndSearch()를 실행하도록 하고 싶습니다.
추후 키워드 관련 추천 종목 조회/추천 종목의 검색량 조회/두 api를 동시에 실행하는 서비스 등으로 keywordservice에 가해지는 부담을 덜 예정입니다. 현재는 일단 흐름이나 오류 위주로 봐주세요.
엔티티에 존재하는 미사용된 getter/setter등은 추후 연결이 마무리된 후에 정리할 예정입니다.
현재 mysql의 stock, keyword 테이블에 임시 데이터를 넣어 실행하였습니다. 추후 stock 테이블에 데이터를 불러오는 api를 실행 후 processRecommendStockAndSearch()를 실행하게 하면 정상적으로 작동될 것 같습니다.

- 엔티티
JPA 매핑을 설정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
repository의 메소드들의 이름을 변경하고 싶은데 추천해주실 수 있을까요? 당장은 일단 인텔리제이와 스프링부트에서 자동으로 인식할 수 있는 이름으로 작성해서 굉장히... 길어졌습니다.(예 : SearchVolumeRepository의 findByKeyword_KeywordIdAndRecommendKeywordStock_RecommendStockId 등...)  가급적이면 변경하는 방법을 찾아 변경할 예정입니다.
