### PR TITLE
키워드 뉴스 통합 프로세스 추가, 스케줄러에 키워드 프로세스 추가

### DIFF
--- a/src/main/java/com/estsoft/astronautbe/config/Scheduler.java
+++ b/src/main/java/com/estsoft/astronautbe/config/Scheduler.java
@@ -1,9 +1,15 @@
 package com.estsoft.astronautbe.config;
 
+import java.util.List;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.estsoft.astronautbe.domain.Keyword;
+import com.estsoft.astronautbe.service.KeywordService;
 import com.estsoft.astronautbe.service.KrxApiService;
+import com.estsoft.astronautbe.service.PopularKeywordService;
+import com.estsoft.astronautbe.service.keywordNews.KeywordNewsService;
 
 import jakarta.transaction.Transactional;
 
@@ -11,18 +17,33 @@ import jakarta.transaction.Transactional;
 public class Scheduler {
 
 	private final KrxApiService krxApiService;
+	private final PopularKeywordService popularKeywordService;
+	private final KeywordService keywordService;
+	private final KeywordNewsService keywordNewsService;
 
-	public Scheduler(KrxApiService krxApiService) {
+	public Scheduler(KrxApiService krxApiService, PopularKeywordService popularKeywordService,
+		KeywordService keywordService, KeywordNewsService keywordNewsService) {
 		this.krxApiService = krxApiService;
+		this.popularKeywordService = popularKeywordService;
+		this.keywordService = keywordService;
+		this.keywordNewsService = keywordNewsService;
 	}
 
 	@Transactional
-	@Scheduled(cron = "0 10 11 * * ?")
-	public void schedule() {
+	@Scheduled(cron = "0 30 5 * * ?")
+	public void stockSchedule() {
 		String responseKospi = krxApiService.getKrxKospiDataForYesterday();
 		krxApiService.saveKrxData(responseKospi);
 
 		String responseKosdaq = krxApiService.getKrxKosdaqDataForYesterday();
 		krxApiService.saveKrxData(responseKosdaq);
+	}
+
+	@Transactional
+	@Scheduled(cron = "0 0 6 * * ?")
+	public void keywordSchedule() {
+		List<Keyword> keywords = popularKeywordService.getYesterdayPopularKeywords();
+		keywordService.processKeywordRecommendation();
+		keywordNewsService.processKeywordNews();
 	}
 }

--- a/src/main/java/com/estsoft/astronautbe/controller/keywordNews/AllenAIController.java
+++ b/src/main/java/com/estsoft/astronautbe/controller/keywordNews/AllenAIController.java
@@ -17,7 +17,7 @@ public class AllenAIController {
 
 	@GetMapping("/allen_api")
 	public ResponseEntity<String> allenApi() {
-		String response = allenAIService.getAnswerFromAllenAI();
+		String response = allenAIService.getAnswerFromAllenAI(1L); // 임시 keywordId
 		allenAIService.saveNewsToDatabase(response);
 
 		return ResponseEntity.ok(response);

--- a/src/main/java/com/estsoft/astronautbe/controller/keywordNews/KeywordNewsController.java
+++ b/src/main/java/com/estsoft/astronautbe/controller/keywordNews/KeywordNewsController.java
@@ -4,9 +4,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.estsoft.astronautbe.domain.dto.keywordNews.KeywordNewsResponseDTO;
@@ -29,5 +29,11 @@ public class KeywordNewsController {
 				"message", "키워드 뉴스 전체 조회 성공",
 				"data", newsList
 			));
+	}
+
+	@PostMapping("/api/keywords/news/allProcess")
+	public ResponseEntity<?> allProcess() {
+		keywordNewsService.processKeywordNews();
+		return ResponseEntity.ok("전체 프로세스 실행 성공");
 	}
 }

--- a/src/main/java/com/estsoft/astronautbe/controller/keywordNews/NewsApiController.java
+++ b/src/main/java/com/estsoft/astronautbe/controller/keywordNews/NewsApiController.java
@@ -19,7 +19,7 @@ public class NewsApiController {
 	@GetMapping("/news_api")
 	public ResponseEntity<String> newsApi(@RequestParam("query") String query) {
 		String responseBody = service.getNews(query);
-		service.saveNewsToDatabase(responseBody);
+		service.saveNewsToDatabase(responseBody, 1L); // 임시 keywordId
 		return ResponseEntity.ok(responseBody);
 	}
 }

--- a/src/main/java/com/estsoft/astronautbe/repository/KeywordNewsRepository.java
+++ b/src/main/java/com/estsoft/astronautbe/repository/KeywordNewsRepository.java
@@ -9,4 +9,6 @@ import com.estsoft.astronautbe.domain.KeywordNews;
 
 public interface KeywordNewsRepository extends JpaRepository<KeywordNews, Long> {
 	List<KeywordNews> findTop10ByKeywordOrderByCreatedAtDesc(Keyword keywordId);
+
+	List<KeywordNews> findByKeyword_KeywordId(Long keywordId);
 }

--- a/src/main/java/com/estsoft/astronautbe/service/KeywordService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/KeywordService.java
@@ -1,15 +1,5 @@
 package com.estsoft.astronautbe.service;
 
-import com.estsoft.astronautbe.domain.Keyword;
-import com.estsoft.astronautbe.domain.RecommendKeywordStock;
-import com.estsoft.astronautbe.domain.SearchVolume;
-import com.estsoft.astronautbe.domain.Stock;
-import com.estsoft.astronautbe.domain.dto.RecommendKeywordStockDTO;
-import com.estsoft.astronautbe.domain.dto.SearchVolumeWithStockDTO;
-import com.estsoft.astronautbe.repository.StockRepository;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -26,13 +16,22 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.estsoft.astronautbe.config.ApiConstants;
+import com.estsoft.astronautbe.domain.Keyword;
+import com.estsoft.astronautbe.domain.RecommendKeywordStock;
+import com.estsoft.astronautbe.domain.SearchVolume;
+import com.estsoft.astronautbe.domain.Stock;
+import com.estsoft.astronautbe.domain.dto.RecommendKeywordStockDTO;
 import com.estsoft.astronautbe.domain.dto.RecommendStockAnswer;
 import com.estsoft.astronautbe.domain.dto.SearchVolumeRequestDTO;
 import com.estsoft.astronautbe.domain.dto.SearchVolumeResponseDTO;
+import com.estsoft.astronautbe.domain.dto.SearchVolumeWithStockDTO;
 import com.estsoft.astronautbe.repository.KeywordRepository;
 import com.estsoft.astronautbe.repository.RecommendKeywordStockRepository;
 import com.estsoft.astronautbe.repository.SearchVolumeRepository;
+import com.estsoft.astronautbe.repository.StockRepository;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Service
 public class KeywordService {
@@ -48,7 +47,7 @@ public class KeywordService {
 	@Value("${naver.client.secret}")
 	private String naverClientSecret;
 
-	@Value("${alan.client.id}")
+	@Value("${ALLEN_API_ID}")
 	private String alanClientId;
 
 	private final WebClient webClient;
@@ -124,7 +123,9 @@ public class KeywordService {
 	// 응답 가공
 	private List<RecommendKeywordStock> parseRecommendKeywordStock(String stringResponse, Long keywordId) throws
 			Exception {
-		stringResponse = stringResponse.replace("\\n", "");
+		stringResponse = stringResponse.replace("\\n", "")     // 줄바꿈 제거
+			.replace("```json", "") // ```json 제거
+			.replace("```", "");    // 닫는 백틱 제거
 
 		// json으로 파싱
 		JsonNode rootNode = objectMapper.readTree(stringResponse);

--- a/src/main/java/com/estsoft/astronautbe/service/PopularKeywordService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/PopularKeywordService.java
@@ -39,7 +39,9 @@ public class PopularKeywordService {
 		}
 
 		String url = allenApiUrl;
-		String content = "전날 주식시장 종목명을 제외한 인기 키워드 10개를 정리하고 뉴스를 제거하고 키워드명, 관심도는 상대적으로 1~100으로, 순위, 이유, 긍정이면 0으로 하고 부정적이면 1로 정리해서 json 형태로만 알려줘 필드의 값은 keywordName, interest, ranking, reason, emotion 순서로 알려줘";
+		String content = "전날 주식시장 종목명을 제외한 인기 키워드 10개를 정리하고 뉴스를 제거하고 키워드명, 관심도는 상대적으로 1~100으로, 순위, 이유, 긍정이면 0으로 하고 부정적이면 1로 정리해서 json 형태로만 알려줘. "
+			+ "필드의 값은 keywordName, interest, ranking, reason, emotion 순서로 알려줘. "
+			+ "reason은 최소 100자 이상으로 작성해줘.";
 		String requestUrl = String.format("%s?content=%s&client_id=%s", url, content, allenApiId);
 
 		HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/estsoft/astronautbe/service/PopularKeywordService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/PopularKeywordService.java
@@ -1,103 +1,108 @@
 package com.estsoft.astronautbe.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.estsoft.astronautbe.config.ApiConstants;
 import com.estsoft.astronautbe.domain.Keyword;
 import com.estsoft.astronautbe.repository.KeywordRepository;
 import com.estsoft.astronautbe.util.JsonParserUtil;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 public class PopularKeywordService {
 
-    @Value("${ALLEN_API_ID}")
-    private String allenApiId;
+	@Value("${ALLEN_API_ID}")
+	private String allenApiId;
 
-    @Value("${ALLEN_API_URL}")
-    private String allenApiUrl;
+	private String allenApiUrl = ApiConstants.ALLEN_API_URL;
 
-    private final RestTemplate restTemplate = new RestTemplate();
-    private final KeywordRepository keywordRepository;
+	private final RestTemplate restTemplate = new RestTemplate();
+	private final KeywordRepository keywordRepository;
 
-    public PopularKeywordService(KeywordRepository keywordRepository) {
-        this.keywordRepository = keywordRepository;
-    }
+	public PopularKeywordService(KeywordRepository keywordRepository) {
+		this.keywordRepository = keywordRepository;
+	}
 
-    public List<Keyword> getYesterdayPopularKeywords() {
-        if (allenApiId == null || allenApiUrl == null) {
-            throw new IllegalArgumentException("API ID or URL is not set");
-        }
+	public List<Keyword> getYesterdayPopularKeywords() {
+		if (allenApiId == null || allenApiUrl == null) {
+			throw new IllegalArgumentException("API ID or URL is not set");
+		}
 
-        String url = allenApiUrl + "/api/v1/question";
-        String content = "전날 주식시장 인기 키워드 10개를 정리하고 뉴스를 제거하고 키워드명, 관심도는 상대적으로 1~100으로, 순위, 이유, 긍정이면 0으로 하고 부정적이면 1로 정리해서 json 형태로만 알려줘 필드의 값은 keywordName, interest, ranking, reason, emotion 순서로 알려줘";
-        String requestUrl = String.format("%s?content=%s&client_id=%s", url, content, allenApiId);
+		String url = allenApiUrl;
+		String content = "전날 주식시장 종목명을 제외한 인기 키워드 10개를 정리하고 뉴스를 제거하고 키워드명, 관심도는 상대적으로 1~100으로, 순위, 이유, 긍정이면 0으로 하고 부정적이면 1로 정리해서 json 형태로만 알려줘 필드의 값은 keywordName, interest, ranking, reason, emotion 순서로 알려줘";
+		String requestUrl = String.format("%s?content=%s&client_id=%s", url, content, allenApiId);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Accept", "application/json");
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Accept", "application/json");
 
-        HttpEntity<String> entity = new HttpEntity<>(headers);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<String> responseEntity = restTemplate.exchange(
-                requestUrl,
-                HttpMethod.GET,
-                entity,
-                String.class
-        );
+		ResponseEntity<String> responseEntity = restTemplate.exchange(
+			requestUrl,
+			HttpMethod.GET,
+			entity,
+			String.class
+		);
 
-        String rawResponse = responseEntity.getBody();
+		String rawResponse = responseEntity.getBody();
 
-        // JSON 파싱 전 본문에서 JSON을 추출
-        String responseBody = JsonParserUtil.extractJsonFromContent(rawResponse);
+		// JSON 파싱 전 본문에서 JSON을 추출
+		String responseBody = JsonParserUtil.extractJsonFromContent(rawResponse);
 
-        return saveKeywordsToDatabase(responseBody);
-    }
+		return saveKeywordsToDatabase(responseBody);
+	}
 
-    private List<Keyword> saveKeywordsToDatabase(String responseBody) {
-        if (responseBody == null) {
-            throw new IllegalArgumentException("Response body is null");
-        }
+	private List<Keyword> saveKeywordsToDatabase(String responseBody) {
+		if (responseBody == null) {
+			throw new IllegalArgumentException("Response body is null");
+		}
 
-        List<Keyword> keywords = new ArrayList<>();
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode itemsNode = objectMapper.readTree(responseBody);
+		List<Keyword> keywords = new ArrayList<>();
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+			JsonNode itemsNode = objectMapper.readTree(responseBody);
 
-            if (itemsNode != null && itemsNode.isArray()) {
-                // 기존 데이터 삭제
-                // keywordRepository.deleteAll();
+			if (itemsNode != null && itemsNode.isArray()) {
+				// 기존 데이터 삭제
+				// keywordRepository.deleteAll();
 
-                for (JsonNode itemNode : itemsNode) {
-                    // 각 필드별 null 체크
-                    JsonNode keywordNameNode = itemNode.get("keywordName");
-                    JsonNode interestNode = itemNode.get("interest");
-                    JsonNode rankingNode = itemNode.get("ranking");
-                    JsonNode reasonNode = itemNode.get("reason");
-                    JsonNode emotionNode = itemNode.get("emotion");
+				for (JsonNode itemNode : itemsNode) {
+					// 각 필드별 null 체크
+					JsonNode keywordNameNode = itemNode.get("keywordName");
+					JsonNode interestNode = itemNode.get("interest");
+					JsonNode rankingNode = itemNode.get("ranking");
+					JsonNode reasonNode = itemNode.get("reason");
+					JsonNode emotionNode = itemNode.get("emotion");
 
-                    if (keywordNameNode == null || interestNode == null ||
-                            rankingNode == null || reasonNode == null || emotionNode == null) {
-                        throw new IllegalArgumentException("Some fields are missing in itemNode: " + itemNode.toString());
-                    }
-                    Keyword keyword = new Keyword();
-                    keyword.setKeywordName(keywordNameNode.asText());
-                    keyword.setInterest(interestNode.asInt());
-                    keyword.setRanking(rankingNode.asInt());
-                    keyword.setReason(reasonNode.asText());
-                    keyword.setEmotion(emotionNode.asInt());
-                    keywords.add(keywordRepository.save(keyword));
-                }
-            } else {
-                throw new IllegalArgumentException("Response body is not an array");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Error saving keywords to database", e);
-        }
-        return keywords;
-    }
+					if (keywordNameNode == null || interestNode == null ||
+						rankingNode == null || reasonNode == null || emotionNode == null) {
+						throw new IllegalArgumentException(
+							"Some fields are missing in itemNode: " + itemNode.toString());
+					}
+					Keyword keyword = new Keyword();
+					keyword.setKeywordName(keywordNameNode.asText());
+					keyword.setInterest(interestNode.asInt());
+					keyword.setRanking(rankingNode.asInt());
+					keyword.setReason(reasonNode.asText());
+					keyword.setEmotion(emotionNode.asInt());
+					keywords.add(keywordRepository.save(keyword));
+				}
+			} else {
+				throw new IllegalArgumentException("Response body is not an array");
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Error saving keywords to database", e);
+		}
+		return keywords;
+	}
 }

--- a/src/main/java/com/estsoft/astronautbe/service/keywordNews/KeywordNewsService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/keywordNews/KeywordNewsService.java
@@ -1,5 +1,6 @@
 package com.estsoft.astronautbe.service.keywordNews;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -9,15 +10,23 @@ import com.estsoft.astronautbe.domain.KeywordNews;
 import com.estsoft.astronautbe.domain.dto.keywordNews.KeywordNewsResponseDTO;
 import com.estsoft.astronautbe.repository.KeywordNewsRepository;
 import com.estsoft.astronautbe.repository.KeywordRepository;
+import com.estsoft.astronautbe.service.KeywordService;
 
 @Service
 public class KeywordNewsService {
 	private final KeywordRepository keywordRepository;
 	private final KeywordNewsRepository keywordNewsRepository;
+	private final KeywordService keywordService;
+	private final NaverNewsApiService naverNewsApiService;
+	private final AllenAIService allenAIService;
 
-	public KeywordNewsService(KeywordRepository keywordRepository, KeywordNewsRepository keywordNewsRepository) {
+	public KeywordNewsService(KeywordRepository keywordRepository, KeywordNewsRepository keywordNewsRepository,
+		KeywordService keywordService, NaverNewsApiService naverNewsApiService, AllenAIService allenAIService) {
 		this.keywordRepository = keywordRepository;
 		this.keywordNewsRepository = keywordNewsRepository;
+		this.keywordService = keywordService;
+		this.naverNewsApiService = naverNewsApiService;
+		this.allenAIService = allenAIService;
 	}
 
 	public List<KeywordNewsResponseDTO> getKeywordNewsByKeywordId(Long keywordId) {
@@ -27,5 +36,21 @@ public class KeywordNewsService {
 		return newsList.stream()
 			.map(KeywordNewsResponseDTO::fromEntity)
 			.toList();
+	}
+
+	public void processKeywordNews() {
+
+		LocalDateTime today = LocalDateTime.now();
+		List<Long> todayKeywordIds = keywordService.getTodayKeywordIds(today);
+
+		for (Long keywordId : todayKeywordIds) {
+			String keywordName = keywordService.getKeywordNameById(keywordId);
+
+			String response = naverNewsApiService.getNews(keywordName);
+			naverNewsApiService.saveNewsToDatabase(response, keywordId);
+
+			response = allenAIService.getAnswerFromAllenAI(keywordId);
+			allenAIService.saveNewsToDatabase(response);
+		}
 	}
 }

--- a/src/main/java/com/estsoft/astronautbe/service/keywordNews/NaverNewsApiService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/keywordNews/NaverNewsApiService.java
@@ -55,7 +55,7 @@ public class NaverNewsApiService {
 		return get(apiURL, requestHeaders);
 	}
 
-	public void saveNewsToDatabase(String responseBody) {
+	public void saveNewsToDatabase(String responseBody, Long keywordId) {
 		try {
 			ObjectMapper objectMapper = new ObjectMapper();
 			JsonNode rootNode = objectMapper.readTree(responseBody);
@@ -76,7 +76,7 @@ public class NaverNewsApiService {
 						throw new RuntimeException("날짜 형식 변환 실패: " + pubDateString, e);
 					}
 
-					Keyword keyword = keywordRepository.findById(1L).orElse(null);
+					Keyword keyword = keywordRepository.findById(keywordId).orElse(null);
 					KeywordNews news = new KeywordNews(keyword, title, null, link, pubDate, null, null);
 					repository.save(news);
 				}

--- a/src/test/java/com/estsoft/astronautbe/controller/keywordNews/AllenAIControllerTest.java
+++ b/src/test/java/com/estsoft/astronautbe/controller/keywordNews/AllenAIControllerTest.java
@@ -37,7 +37,7 @@ class AllenAIControllerTest {
 	void testAllenApi() throws Exception {
 		// given
 		String mockResponse = "This is a mock response from Allen AI";
-		when(allenAIService.getAnswerFromAllenAI()).thenReturn(mockResponse);
+		when(allenAIService.getAnswerFromAllenAI(1L)).thenReturn(mockResponse);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(get("/allen_api")
@@ -47,6 +47,6 @@ class AllenAIControllerTest {
 		resultActions.andExpect(status().isOk())
 			.andExpect(content().string(mockResponse));
 
-		verify(allenAIService, times(1)).getAnswerFromAllenAI();
+		verify(allenAIService, times(1)).getAnswerFromAllenAI(1L);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #33 

## 📝작업 내용

> 키워드 뉴스 통합 프로세스 추가
> 매일 오전 6시마다 키워드 추천, 키워드 종목 추천, 종목 검색량, 키워드 뉴스 저장
> 동시 스케줄러는 부담일 것 같아서 주식 조회 스케줄러는 오전 5시 반으로 세팅

## 💬리뷰 요구사항(선택)

> 테스트 해보면서 다른 분들의 코드를 좀 건드려서 수정한 부분 위주로 리뷰 부탁드립니다!
> PopularKeywordService 이 코드는 url과 프롬프트 부분만 수정했는데 전체 코드가 수정되었다고 나오네요ㅜㅜ 왜 그런지는 모르겠습니다...
