### PR TITLE
FEAT: React 연결용 api 생성

### DIFF
--- a/src/main/java/com/estsoft/astronautbe/controller/keyword/PopularKeywordController.java
+++ b/src/main/java/com/estsoft/astronautbe/controller/keyword/PopularKeywordController.java
@@ -24,4 +24,11 @@ public class PopularKeywordController {
         List<Keyword> keywords = popularKeywordService.getYesterdayPopularKeywords();
         return ResponseEntity.ok(keywords);
     }
+
+    // 최근 키워드를 DB에서 가져오는 api(alan 사용X)
+    @GetMapping("/popular/react")
+    public ResponseEntity<List<Keyword>> getPopularKeywordsForReact(){
+        List<Keyword> keywords = popularKeywordService.getPopularKeywordsForReact();
+        return ResponseEntity.ok(keywords);
+    }
 }

--- a/src/main/java/com/estsoft/astronautbe/service/PopularKeywordService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/PopularKeywordService.java
@@ -1,5 +1,6 @@
 package com.estsoft.astronautbe.service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -106,5 +107,12 @@ public class PopularKeywordService {
 			throw new RuntimeException("Error saving keywords to database", e);
 		}
 		return keywords;
+	}
+
+	// 리액트 반환용 (ALAN에게서 매번 호출하는 방식이 아닌 DB에서 가져오는 방식)
+	public List<Keyword> getPopularKeywordsForReact() {
+		LocalDateTime startOfDay = LocalDateTime.now().toLocalDate().atStartOfDay();
+		LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
+		return keywordRepository.findByCreatedAtToday(startOfDay, endOfDay);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

프론트엔드 관련이라 이슈 번호가 연동이 안됩니다...!

## 📝작업 내용

프론트엔드에서 keyword 관련 정보(순위, 추천 사유 등등)을 표시하기 원활하도록 API를 추가로 생성하였습니다.
기존의 API 와는 달리, DB에 저장된 값을 불러오는 방식이므로 Alan API의 횟수를 소모하지 않으며 호출 속도가 빨라졌습니다. 
react에서 값을 불러오는 용으로만 사용하는 API이므로 DB에 저장하는 용도로는 사용할 수 없습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


