### PR TITLE
Fix: 주식 상세 조회 api 로직 수정

### DIFF
--- a/src/main/java/com/estsoft/astronautbe/controller/stock/StockController.java
+++ b/src/main/java/com/estsoft/astronautbe/controller/stock/StockController.java
@@ -44,4 +44,16 @@ public class StockController {
 				"data", stock
 			));
 	}
+
+	// stock -> recommend_stock_id parameter로 받아서 stock_code 조회해서 리턴
+	@GetMapping("/stock_detail")
+	public ResponseEntity<?> getStock(@RequestParam(name = "stockId") Long stockId,
+		@RequestParam(name = "dataType") String stockType) {
+		StockDetailResponseDTO stock = stockService.findStockByRecommendStockId(stockType, stockId);
+		return ResponseEntity.ok()
+			.body(Map.of(
+				"message", "종목 상세 조회 성공",
+				"data", stock
+			));
+	}
 }

--- a/src/main/java/com/estsoft/astronautbe/repository/KeywordRepository.java
+++ b/src/main/java/com/estsoft/astronautbe/repository/KeywordRepository.java
@@ -23,4 +23,6 @@ public interface KeywordRepository extends JpaRepository<Keyword,Long> {
 
 	List<Keyword> findAllByOrderByInterestAsc();
 
+	List<Keyword> findTop10ByOrderByCreatedAtDescRankingAsc();
+
 }

--- a/src/main/java/com/estsoft/astronautbe/service/GetKeywordService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/GetKeywordService.java
@@ -26,6 +26,10 @@ public class GetKeywordService {
     public List<Keyword> getTodayKeywords() {
         LocalDateTime startOfDay = LocalDateTime.now().with(LocalTime.MIN);
         LocalDateTime endOfDay = LocalDateTime.now().with(LocalTime.MAX);
-        return keywordRepository.findByCreatedAtToday(startOfDay, endOfDay);
+        List<Keyword> keywords = keywordRepository.findByCreatedAtToday(startOfDay, endOfDay);
+        if (keywords.isEmpty()) {
+            return keywordRepository.findTop10ByOrderByCreatedAtDescRankingAsc();
+        }
+        return keywords;
     }
 }

--- a/src/main/java/com/estsoft/astronautbe/service/PopularKeywordService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/PopularKeywordService.java
@@ -40,7 +40,7 @@ public class PopularKeywordService {
 		}
 
 		String url = allenApiUrl;
-		String content = "전날 주식시장 종목명을 제외한 인기 키워드 10개를 정리하고 뉴스를 제거하고 키워드명, 관심도는 상대적으로 1~100으로, 순위, 이유, 긍정이면 0으로 하고 부정적이면 1로 정리해서 json 형태로만 알려줘. "
+		String content = "전날 주식시장 종목명을 제외한 인기 키워드 10개를 정리하고 뉴스를 제거하고 키워드명, 관심도는 상대적으로 1~100으로, 순위, 이유, 긍정이면 0으로 하고 부정적이면 1로 정리해서 json 배열 형태로만 알려줘. "
 			+ "필드의 값은 keywordName, interest, ranking, reason, emotion 순서로 알려줘. "
 			+ "reason은 최소 100자 이상으로 작성해줘.";
 		String requestUrl = String.format("%s?content=%s&client_id=%s", url, content, allenApiId);

--- a/src/main/java/com/estsoft/astronautbe/service/StockService.java
+++ b/src/main/java/com/estsoft/astronautbe/service/StockService.java
@@ -4,18 +4,22 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.estsoft.astronautbe.domain.RecommendKeywordStock;
 import com.estsoft.astronautbe.domain.Stock;
 import com.estsoft.astronautbe.domain.dto.stock.StockDetailResponseDTO;
 import com.estsoft.astronautbe.domain.dto.stock.StockResponseDTO;
+import com.estsoft.astronautbe.repository.RecommendKeywordStockRepository;
 import com.estsoft.astronautbe.repository.StockRepository;
 
 @Service
 public class StockService {
 
 	private final StockRepository stockRepository;
+	private final RecommendKeywordStockRepository stockKeywordRepository;
 
-	public StockService(StockRepository stockRepository) {
+	public StockService(StockRepository stockRepository, RecommendKeywordStockRepository stockKeywordRepository) {
 		this.stockRepository = stockRepository;
+		this.stockKeywordRepository = stockKeywordRepository;
 	}
 
 	public List<StockResponseDTO> findStockByQuery(String query) {
@@ -32,6 +36,19 @@ public class StockService {
 	}
 
 	public Stock findStockById(String stockCode) {
-		return stockRepository.findById(stockCode).orElseThrow(() -> new IllegalArgumentException(stockCode + "에 해당하는 종목이 없습니다."));
+		return stockRepository.findById(stockCode)
+			.orElseThrow(() -> new IllegalArgumentException(stockCode + "에 해당하는 종목이 없습니다."));
+	}
+
+	public StockDetailResponseDTO findStockByRecommendStockId(String stockType, Long stockId) {
+		Stock stock;
+		if (stockType.equals("RecommendKeywordStockDTO")) {
+			RecommendKeywordStock recommendKeywordStock = stockKeywordRepository.findByRecommendStockId(stockId);
+			stock = recommendKeywordStock.getStock();
+		} else {
+			stock = stockRepository.findById(stockId.toString())
+				.orElseThrow(() -> new IllegalArgumentException(stockId + "의 stock 정보가 없습니다."));
+		}
+		return StockDetailResponseDTO.fromEntity(stock);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 프론트쪽 연결 로직 수정이라 이슈가 없습니다

## 📝작업 내용

> 메인화면 키워드 조회 시 오늘의 데이터가 없으면 최신 10개의 데이터 조회해오기
> 키워드 상세 화면에서 종목에 따른 팝업 데이터 조회 로직 수정
